### PR TITLE
Fix Spring Boot 1.4 upgrade

### DIFF
--- a/components/movies-data-access/build.gradle
+++ b/components/movies-data-access/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
     compile "org.springframework:spring-jdbc:$springVersion"
     compile "org.springframework:spring-context:$springVersion"
+    compile "org.springframework.boot:spring-boot-starter:$springBootVersion"
 
     testCompile "org.springframework.boot:spring-boot-starter-test:$springBootVersion"
     testCompile "com.zaxxer:HikariCP:$hikariVersion"

--- a/components/movies-data-access/src/test/java/io/damo/apppropsexample/movies/RepositoryTestConfiguration.java
+++ b/components/movies-data-access/src/test/java/io/damo/apppropsexample/movies/RepositoryTestConfiguration.java
@@ -1,10 +1,11 @@
 package io.damo.apppropsexample.movies;
 
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.JdbcTemplateAutoConfiguration;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
 @Configuration
-@Import(DataSourceAutoConfiguration.class)
+@Import({ DataSourceAutoConfiguration.class, JdbcTemplateAutoConfiguration.class })
 public class RepositoryTestConfiguration {
 }


### PR DESCRIPTION
Re-add `spring-boot-starter` dependency to the `movies-data-access`
components. In the previous version the `spring-boot-starter` dependency
was used in `testCompile`. During the upgrade this was changed to
`spring-boot-starter-test` meaning that the snakeyaml library was no
longer included. This has the knock on effect of meaning the
`application.yml` test config was ignored.

Update `RepositoryTestConfiguration` to directly import
`JdbcTemplateAutoConfiguration`. In Spring Boot 1.3 the `JdbcTemplate`
was defined in `DataSourceAutoConfiguration` but in Spring Boot 1.4
this changed. See Spring Boot issue 6449 for details.